### PR TITLE
Resolve pre-commit hook running multiple times

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v1.20.2

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
   description: Runs Checkstyle
   entry: checkstyle
   language: python
+  require_serial: true


### PR DESCRIPTION
# Problem

Error getting multiple messages when running checkstyle using pre-commit

```
checkstyle...............................................................Passed
- hook id: checkstyle
- duration: 0.63s

Starting audit...
[WARN] /Users/jeonghun/workspace/spring-boot-reactive-starter/src/main/java/io/vanslog/springboot/ReactiveStarter.java:6:1: Missing a Javadoc comment. [MissingJavadocType]
Audit done.
Starting audit...
Audit done.
Starting audit...
Audit done.
Starting audit...
Audit done.
```

# Solution

Add `require_serial: true` option to `.pre-commit-hooks.yaml`
