### PR TITLE
feat: Change checkstyle cache path

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+appdirs==1.4.4
 build==0.8.0
 requests==2.28.1
 tox==3.25.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
+    appdirs
     requests
     tqdm
 python_requires = >=3.7

--- a/src/checkstyle/application.py
+++ b/src/checkstyle/application.py
@@ -14,12 +14,13 @@ class Application:
     def run(self, argv: Optional[Sequence[str]]) -> int:
         args_dict = self._parser.parse_args_dict(argv)
 
-        checkstyle_version = args_dict.pop('version')
-        binary_file = self._store.download_checkstyle(checkstyle_version)
+        version = args_dict.pop('version')
         files = args_dict.pop('files')
 
+        filename = self._store.download_checkstyle(version)
+
         exit_code = run_command(
-            target=self._store.get_checkstyle_cache(binary_file),
+            target=self._store.get_checkstyle_cache(filename=filename),
             args=self._parser.convert_args_dict_to_list(args_dict) + files,
         )
         return exit_code

--- a/src/checkstyle/utils/store.py
+++ b/src/checkstyle/utils/store.py
@@ -1,22 +1,27 @@
 import os
 
 import requests
+from appdirs import user_cache_dir
 from tqdm import tqdm
 
 
 class Store:
+
     def download_checkstyle(self, version: str) -> str:
         filename = self._get_checkstyle_filename(version)
         if not self._is_exist_file(filename):
             try:
-                url = self._get_checkstyle_download_url(version)
-                self._download(url=url, filename=filename)
+                self._download(
+                    url=self._get_checkstyle_download_url(version),
+                    filename=self._get_checkstyle_filename(version),
+                    target=self.get_checkstyle_cache(filename),
+                )
             except requests.exceptions.HTTPError as e:
                 print(e)
         return filename
 
     def get_checkstyle_cache(self, filename: str) -> str:
-        cache_path = os.path.join(os.getcwd(), ".checkstyle_cache")
+        cache_path = user_cache_dir('checkstyle')
         if not os.path.exists(cache_path):
             os.makedirs(cache_path)
         return os.path.join(cache_path, filename)
@@ -48,12 +53,12 @@ class Store:
         download_url = _prefix_url.format(version=version)
         return download_url
 
-    def _download(self, url: str, filename: str) -> None:
+    def _download(self, url: str, filename: str, target: str) -> None:
         r = requests.get(url + filename, stream=True)
         r.raise_for_status()
         total = int(r.headers.get('Content-Length', 0))
 
-        with open(self.get_checkstyle_cache(filename), "wb") as f, tqdm(
+        with open(target, "wb") as f, tqdm(
             desc=filename,
             total=total,
             unit='iB',


### PR DESCRIPTION
Previously, the cache was stored in the path that operated the program.
It has been modified to use the same cache path no matter which path the program runs on.

For this purpose, I added `appdirs` package to dependencies.
The cache paths that will be used in the future are as follows:

- Linux: `~/.cache/checkstyle`
- Mac OS X: `~/Library/Caches/checkstyle`
- Windows: `%LocalAppData%\checkstyle\checkstyle\Cache`