### PR TITLE
fix: Resolve error while readthedocs deployment

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 sphinx==5.1.1
 furo==2022.6.21
 readthedocs-sphinx-search==0.1.2
+appdirs==1.4.4
+tqdm==4.64.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
+    'sphinx_search.extension',
 ]
 
 source_suffix = '.rst'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,6 @@ language = 'en'
 
 # -- Options for HTML output -------------------------------------------------
 html_theme = 'furo'
-html_static_path = ['_static']
 
 # -- Autodoc configuration ---------------------------------------------------
 autodoc_member_order = 'bysource'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,6 +8,13 @@ copyright = '2022, junghoon-vans'
 author = 'junghoon-vans'
 
 # -- General configuration ---------------------------------------------------
+language = 'en'
+
+templates_path = ['_templates']
+exclude_patterns = ['Thumbs.db', '.DS_Store']
+
+pygments_style = 'sphinx'
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
@@ -18,12 +25,6 @@ extensions = [
 
 source_suffix = '.rst'
 master_doc = 'index'
-pygments_style = 'sphinx'
-
-templates_path = ['_templates']
-exclude_patterns = ['Thumbs.db', '.DS_Store']
-
-language = 'en'
 
 # -- Options for HTML output -------------------------------------------------
 html_theme = 'furo'


### PR DESCRIPTION
Changes
---

- Resolve '_static' does not exist error
- Add sphinx_search extension to enable search
- Update requirements for docs to resolve `no module named` error