### PR TITLE
ci: readme autoupdate with bump-version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,7 +23,8 @@ jobs:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Print Version
         run: echo "Bumped to version ${{ steps.cz.outputs.version }}
-      - uses: junghoon-vans/rst-substitution-action@main
+      - if: ${{ steps.cz.outputs.version }}
+        uses: junghoon-vans/rst-substitution-action@main
         with:
           substitutions: "release=v${{ steps.cz.outputs.version }}"
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -22,4 +22,10 @@ jobs:
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Print Version
-        run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
+        run: echo "Bumped to version ${{ steps.cz.outputs.version }}
+      - uses: junghoon-vans/rst-substitution-action@main
+        with:
+          substitutions: "version=${{ steps.cz.outputs.version }}"
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_options: "--amend --no-edit"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "Bumped to version ${{ steps.cz.outputs.version }}
       - uses: junghoon-vans/rst-substitution-action@main
         with:
-          substitutions: "version=${{ steps.cz.outputs.version }}"
+          substitutions: "release=v${{ steps.cz.outputs.version }}"
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_options: "--amend --no-edit"

--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,11 @@ pre-commit
 
 Add this to your ``.pre-commit-config.yaml``
 
-.. code:: yaml
+.. parsed-literal::
 
    repos:
      - repo: https://github.com/junghoon-vans/checkstyle-cli
-       rev: v0.7.0 # Use the ref you want
+       rev: |release|
        hooks:
        - id: checkstyle
 
@@ -57,3 +57,5 @@ License <https://github.com/junghoon-vans/checkstyle-cli/blob/main/LICENSE>`__
 .. |GitHub Workflow Status| image:: https://img.shields.io/github/workflow/status/junghoon-vans/checkstyle-cli/Upload%20Python%20Package
 .. |Documentation Status| image:: https://readthedocs.org/projects/checkstyle-cli/badge/?version=latest
    :target: https://checkstyle-cli.readthedocs.io/en/latest/?badge=latest
+
+.. |release| replace:: v0.7.0


### PR DESCRIPTION
Related Issue
---

ci: Update README.rst automatically when running bump version action #43

Feature
---

README.rst is `automatically` updated with bump-version.
Therefore, version information in README.rst doesn't have to be updated.