### PR TITLE
ci: Update bump-version action

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Bump version and create changelog with commitizen"
     steps:
       - name: Check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: cz

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -21,6 +21,7 @@ jobs:
         uses: commitizen-tools/commitizen-action@master
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          push: false
       - name: Print Version
         run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
       - if: ${{ steps.cz.outputs.version }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,7 +15,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
       - id: cz
         name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master


### PR DESCRIPTION
Changes
---

- Set push option of `commitizen` action to `false` to push with `README.rst`.
- Update version of `checkout` action to `v3`.
- Remove `token` option in `checkout` action.