### PR TITLE
ci: Apply autoupdate badge route

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -25,8 +25,12 @@ jobs:
         run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
       - if: ${{ steps.cz.outputs.version }}
         uses: junghoon-vans/varst-action@v1
+        env:
+          BADGE_LINK: https://img.shields.io/github/actions/workflow/status/junghoon-vans/checkstyle-cli/python-publish.yml
         with:
-          substitutions: "release=v${{ steps.cz.outputs.version }}"
+          substitutions: |
+            'release=v${{ steps.cz.outputs.version }}'
+            'GitHub Workflow Status=${{ env.BADGE_LINK }}?branch=v${{ steps.cz.outputs.version }}'
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_options: "--amend --no-edit"


### PR DESCRIPTION
The path must be modified each time to display the latest version due to the changed shield badge.
This issue can be viewed at the [shields issue #8671](https://github.com/badges/shields/issues/8671)

To solve this problem, I used [varst-action](https://github.com/junghoon-vans/varst-action) to modify the badge path whenever the version was updated.