### PR TITLE
Fix race condition on making directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,7 @@ class FetchBinaries(Command):
         self.set_undefined_options('build', ('build_temp', 'build_dir'))
 
     def run(self):
-        if not os.path.exists(self.build_dir):
-            os.makedirs(self.build_dir)
+        os.makedirs(self.build_dir, exist_ok=True)
 
         download_checkstyle(
             fetch_dir=self.build_dir,

--- a/src/checkstyle/utils/store.py
+++ b/src/checkstyle/utils/store.py
@@ -69,8 +69,7 @@ def get_checkstyle_cache_dir() -> str:
 
     """
     cache_dir = user_cache_dir('checkstyle')
-    if not os.path.exists(cache_dir):
-        os.makedirs(cache_dir)
+    os.makedirs(cache_dir, exist_ok=True)
     return cache_dir
 
 


### PR DESCRIPTION
Running this command in parallel over many files means that I hit the following error:

```
 Traceback (most recent call last):
   File "/var/lib/agent/.cache/uv/builds-v0/.tmphpOzeh/bin/checkstyle", line 10, in <module>
     sys.exit(main())
              ^^^^^^
   File "/var/lib/agent/.cache/uv/builds-v0/.tmphpOzeh/lib/python3.11/site-packages/checkstyle/cli.py", line 19, in main
     exit_code = app.run(argv)
                 ^^^^^^^^^^^^^
   File "/var/lib/agent/.cache/uv/builds-v0/.tmphpOzeh/lib/python3.11/site-packages/checkstyle/application.py", line 31, in run
     fetch_dir=get_checkstyle_cache_dir(),
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/var/lib/agent/.cache/uv/builds-v0/.tmphpOzeh/lib/python3.11/site-packages/checkstyle/utils/store.py", line 73, in get_checkstyle_cache_dir
     os.makedirs(cache_dir)
   File "<frozen os>", line 225, in makedirs
 FileExistsError: [Errno 17] File exists: '/var/lib/agent/.cache/checkstyle'
```

This change avoids that race condition.

## Related Issue

## Description

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests
- [ ] Documentation
- [ ] CI
- [ ] Performance
- [ ] Other

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
